### PR TITLE
Add parspec connector to monitored sites

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -46,6 +46,10 @@ sites:
     url: http://34.69.72.72/health_ai
   - name: Data ingestion service
     url: https://platform.parspec.io/ingestion-service/api/v1/marco
+  - name: parspec connector
+    url: https://apim.workato.com/parspecdev/connector-health-vv1/parspec-connector
+    headers:
+      - "api-token: $RECIPE_TOKEN"
 
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain


### PR DESCRIPTION
Added the parspec connector endpoint with custom API token header to the list of monitored sites in .upptimerc.yml.